### PR TITLE
Added settings, autosave, and fixed editor erase on failed format

### DIFF
--- a/lib/atom-format-lua.js
+++ b/lib/atom-format-lua.js
@@ -1,10 +1,11 @@
 'use babel'
 
-import { CompositeDisposable, Disposable}from 'atom'
+import { CompositeDisposable, Disposable} from 'atom'
 import process from 'child_process';
 import path from 'path';
 import helpers from './help';
 import fs from 'fs';
+import packageConfig from './config-schema.json';
 
 let disposables = null;
 export function activate() {
@@ -19,6 +20,8 @@ export function activate() {
 export function deactivate() {
     disposables.dispose()
 }
+
+export const config = packageConfig;
 
 function format() {
     let editor = null;
@@ -37,6 +40,8 @@ function format() {
     }
 
     tempfile = editor.getPath();
+
+    editor.save();
 
     let pkgDirs = atom.packages.packageDirPaths;
     for (var index = 0; index < pkgDirs.length; index++) {
@@ -58,7 +63,7 @@ function format() {
         'sunos': 'I dont Know where the lua5.1',
         'win32': 'I dont Know where the lua5.1'
     };
-    params = [formatterScript, "--file", tempfile];
+    params = [formatterScript, '--file', tempfile, '--ts', atom.config.get('atom-format-lua.indentSize')];
 
     lua51path = atom.config.get("atom-format-lua.lua51");
 

--- a/lib/config-schema.json
+++ b/lib/config-schema.json
@@ -1,0 +1,12 @@
+{
+  "indentSize": {
+    "description": "Indent size",
+    "type": "integer",
+    "default": 2
+  },
+  "lua51": {
+    "description": "Lua 5.1 location",
+    "type": "string",
+    "default": ""
+  }
+}

--- a/luacode/formatter.lua
+++ b/luacode/formatter.lua
@@ -673,6 +673,8 @@ if not args.filename then error(usage.."no Lua file given") end
 args.mytabsize = args.mytabsize or mytabs
 args.myindent = args.myindent or myindent
 -- print(readfile(args.filename))
-resultText=M.indentcode(readfile(args.filename), '\n', true, '    ')
+resultText=M.indentcode(readfile(args.filename), '\n', true, (' '):rep(args.mytabsize))
 -- print()
-writeFile(args.filename,resultText)
+if resultText then
+  writeFile(args.filename,resultText)
+end


### PR DESCRIPTION
This makes a few changes to fix the problems I was having with the plugin:
- Added settings view with Lua5.1 location and configurable indent size.
- Auto-save editor before formatting. Without doing this the editor must be saved manually or the format will not be successful.
- Check if the format was successful before writing back to the editor. Without this check the editor is cleared on a failed format.
